### PR TITLE
Separate wcsession

### DIFF
--- a/Sources/WatchSync/SessionDelegator.swift
+++ b/Sources/WatchSync/SessionDelegator.swift
@@ -9,12 +9,9 @@ import Combine
 import WatchConnectivity
 
 class SessionDelegater: NSObject, WCSessionDelegate {
-    let subject: PassthroughSubject<Data, Never>
+    static let syncedStateDelegate = SessionDelegater()
     
-    init(subject: PassthroughSubject<Data, Never>) {
-        self.subject = subject
-        super.init()
-    }
+    let dataSubject = PassthroughSubject<Data, Never>()
     
     func session(_ session: WCSession, activationDidCompleteWith activationState: WCSessionActivationState, error: Error?) {
         // Protocol comformance only
@@ -23,7 +20,7 @@ class SessionDelegater: NSObject, WCSessionDelegate {
     
     func session(_ session: WCSession, didReceiveMessageData messageData: Data, replyHandler: @escaping (Data) -> Void) {
         print("Received data from other device")
-        self.subject.send(messageData)
+        self.dataSubject.send(messageData)
         
         // Empty data sent back to other device
         // to show evidence that data was received

--- a/Sources/WatchSync/SyncedWatchState.swift
+++ b/Sources/WatchSync/SyncedWatchState.swift
@@ -85,12 +85,12 @@ import Combine
             .store(in: &cancellables)
     }
     
-    public func syncWithObject<Observable: ObservableObjectPublisher>(_ object: Observable) {
-//        let syncedObject: ObservableObjectPublisher = object.objectWillChange as! ObservableObjectPublisher
+    public func syncWithObject<Observable: ObservableObject>(_ object: Observable) {
+        let syncedObject: ObservableObjectPublisher = object.objectWillChange as! ObservableObjectPublisher
             valueSubject
                 .replaceError(with: wrappedValue)
                 .sink { _ in
-                    object.send()
+                    syncedObject.send()
                 }
                 .store(in: &cancellables)
     }

--- a/Sources/WatchSync/SyncedWatchState.swift
+++ b/Sources/WatchSync/SyncedWatchState.swift
@@ -5,11 +5,11 @@
 //  Created by Chris Gaafary on 5/1/21.
 //
 
-import Foundation
+import SwiftUI
 import WatchConnectivity
 import Combine
 
-@propertyWrapper public class SyncedWatchState<T: Codable> {
+@propertyWrapper public class SyncedWatchState<T: Codable>: DynamicProperty {
     private var session: WCSession
     private let delegate: WCSessionDelegate
     

--- a/Sources/WatchSync/SyncedWatchState.swift
+++ b/Sources/WatchSync/SyncedWatchState.swift
@@ -11,13 +11,11 @@ import Combine
 
 @propertyWrapper public class SyncedWatchState<T: Codable>: DynamicProperty {
     private var session: WCSession
-    private let delegate: WCSessionDelegate
-    //    private let syncedObject: Observable?
     
     private var cancellables = Set<AnyCancellable>()
     
     // SUBJECTS
-    private let dataSubject = PassthroughSubject<Data, Never>()
+    private let dataSubject: PassthroughSubject<Data, Never>
     private let deviceSubject = PassthroughSubject<Device, Never>()
     private let valueSubject: CurrentValueSubject<T, Error>
     
@@ -37,6 +35,7 @@ import Combine
     private var cacheDate = Date()
     private var cachedEncodedObjectData: Data?
     
+    //
     private var receivedData: AnyPublisher<T, Error> {
         dataSubject
             .removeDuplicates()
@@ -70,14 +69,10 @@ import Combine
         get { valueSubject }
     }
     
-    public init(wrappedValue: T, session: WCSession = .default, autoRetryFor timeInterval: TimeInterval = 2) {
-        self.delegate = SessionDelegater(subject: dataSubject)
+    public init(wrappedValue: T, session: WCSession = .syncedStateSession, autoRetryEvery timeInterval: TimeInterval = 2) {
         self.session = session
-        self.session.delegate = self.delegate
-        self.session.activate()
-        
+        self.dataSubject = SessionDelegater.syncedStateDelegate.dataSubject
         self.timer = Timer.publish(every: timeInterval, on: .main, in: .default)
-        
         self.valueSubject = CurrentValueSubject(wrappedValue)
         
         receivedData
@@ -85,6 +80,8 @@ import Combine
             .store(in: &cancellables)
     }
     
+    /// Connects to an ObservableObject to trigger viewupdates in SwiftUI. This could possible break in the future
+    /// - Parameter object: The ObservableObject that will trigger objectWillChange.send() each time a new value is received.
     public func syncWithObject<Observable: ObservableObject>(_ object: Observable) {
         let syncedObject: ObservableObjectPublisher = object.objectWillChange as! ObservableObjectPublisher
         valueSubject

--- a/Sources/WatchSync/SyncedWatchState.swift
+++ b/Sources/WatchSync/SyncedWatchState.swift
@@ -70,7 +70,7 @@ import Combine
         get { valueSubject }
     }
     
-    public init<Observable: ObservableObjectPublisher>(wrappedValue: T, session: WCSession = .default, autoRetryFor timeInterval: TimeInterval = 2, publishOn syncedObject: Observable? = nil) {
+    public init(wrappedValue: T, session: WCSession = .default, autoRetryFor timeInterval: TimeInterval = 2) {
         self.delegate = SessionDelegater(subject: dataSubject)
         self.session = session
         self.session.delegate = self.delegate
@@ -83,16 +83,16 @@ import Combine
         receivedData
             .sink(receiveCompletion: valueSubject.send, receiveValue: valueSubject.send)
             .store(in: &cancellables)
-        
-        if let syncedObject = syncedObject {
+    }
+    
+    public func syncWithObject<Observable: ObservableObjectPublisher>(_ object: Observable) {
+//        let syncedObject: ObservableObjectPublisher = object.objectWillChange as! ObservableObjectPublisher
             valueSubject
                 .replaceError(with: wrappedValue)
                 .sink { _ in
-                    syncedObject.send()
+                    object.send()
                 }
                 .store(in: &cancellables)
-        }
-        
     }
     
     private func send(_ object: T) {

--- a/Sources/WatchSync/SyncedWatchState.swift
+++ b/Sources/WatchSync/SyncedWatchState.swift
@@ -12,7 +12,7 @@ import Combine
 @propertyWrapper public class SyncedWatchState<T: Codable>: DynamicProperty {
     private var session: WCSession
     private let delegate: WCSessionDelegate
-//    private let syncedObject: Observable?
+    //    private let syncedObject: Observable?
     
     private var cancellables = Set<AnyCancellable>()
     
@@ -87,12 +87,12 @@ import Combine
     
     public func syncWithObject<Observable: ObservableObject>(_ object: Observable) {
         let syncedObject: ObservableObjectPublisher = object.objectWillChange as! ObservableObjectPublisher
-            valueSubject
-                .replaceError(with: wrappedValue)
-                .sink { _ in
-                    syncedObject.send()
-                }
-                .store(in: &cancellables)
+        valueSubject
+            .replaceError(with: wrappedValue)
+            .sink { _ in
+                syncedObject.send()
+            }
+            .store(in: &cancellables)
     }
     
     private func send(_ object: T) {
@@ -131,5 +131,16 @@ import Combine
         print("Caching sent data at: \(cacheDate)")
         cachedEncodedObjectData = encodedData
         self.cacheDate = cacheDate
+    }
+}
+
+public extension CurrentValueSubject {
+    func syncWithObject<Observable: ObservableObject>(_ object: Observable) -> AnyCancellable {
+        let syncedObject: ObservableObjectPublisher = object.objectWillChange as! ObservableObjectPublisher
+        return self
+            .replaceError(with: self.value)
+            .sink { _ in
+                syncedObject.send()
+            }
     }
 }

--- a/Sources/WatchSync/WCSession+SyncedSession.swift
+++ b/Sources/WatchSync/WCSession+SyncedSession.swift
@@ -1,0 +1,20 @@
+//
+//  WCSession+SyncedSession.swift
+//  
+//
+//  Created by Chris Gaafary on 5/4/21.
+//
+
+import Foundation
+import WatchConnectivity
+import SwiftUI
+import Combine
+
+public extension WCSession {
+    static let syncedStateSession: WCSession = {
+        let session = WCSession.default
+        session.delegate = SessionDelegater.syncedStateDelegate
+        session.activate()
+        return session
+    }()
+}


### PR DESCRIPTION
WCSession and Delegate are now separated into a singleton. As these should never change in an app lifecycle, this will reduce unneeded delegate instances